### PR TITLE
fix: hide Zendesk widget before triggering load event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,11 +35,12 @@ module.exports = {
 
       root._script.onload = (event) => {
         isLoaded = true
-        root.$emit("loaded", event);
 
         if (options.hideOnLoad) {
           root.hide();
         }
+
+        root.$emit("loaded", event);
       }
 
     };


### PR DESCRIPTION
When `hideOnLoad` is enabled, the widget is hidden _after_ load event
emission. If the caller shows the widget in `onload` callback, it will
be hidden immediately afterward.`onload` callback, it will be hidden
immediately afterward.`onload` callback, it can be hidden immediately
afterward.