### PR TITLE
add isLoaded function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ module.exports = {
 
     let isLoaded = false;
 
+    root.isLoaded = () => isLoaded;
     root.load = zendeskKey => {
       if (isLoaded) {
         return;


### PR DESCRIPTION
if you get "window.zE is not a function", then use condition 
this.$zendesk.isLoaded()